### PR TITLE
Resoruces: Fix issues related to invalid EndTag in ResourceTemplate

### DIFF
--- a/source/include/acexcep.h
+++ b/source/include/acexcep.h
@@ -308,8 +308,9 @@ typedef struct acpi_exception_info
 #define AE_AML_INFINITE_LOOP            EXCEP_AML (0x0021)
 #define AE_AML_UNINITIALIZED_NODE       EXCEP_AML (0x0022)
 #define AE_AML_TARGET_TYPE              EXCEP_AML (0x0023)
+#define AE_AML_INVALID_RESOURCE_LENGTH  EXCEP_AML (0x0024)
 
-#define AE_CODE_AML_MAX                 0x0023
+#define AE_CODE_AML_MAX                 0x0024
 
 
 /*
@@ -435,7 +436,8 @@ static const ACPI_EXCEPTION_INFO    AcpiGbl_ExceptionNames_Aml[] =
     EXCEP_TXT ("AE_AML_ILLEGAL_ADDRESS",        "A memory, I/O, or PCI configuration address is invalid"),
     EXCEP_TXT ("AE_AML_INFINITE_LOOP",          "An apparent infinite AML While loop, method was aborted"),
     EXCEP_TXT ("AE_AML_UNINITIALIZED_NODE",     "A namespace node is uninitialized or unresolved"),
-    EXCEP_TXT ("AE_AML_TARGET_TYPE",            "A target operand of an incorrect type was encountered")
+    EXCEP_TXT ("AE_AML_TARGET_TYPE",            "A target operand of an incorrect type was encountered"),
+    EXCEP_TXT ("AE_AML_INVALID_RESOURCE_LENGTH","Invalid resource length in resource list")
 };
 
 static const ACPI_EXCEPTION_INFO    AcpiGbl_ExceptionNames_Ctrl[] =


### PR DESCRIPTION
There are many inconsistencies in AcpiUtWalkAmlResources():
1. When ResourceTemplate is empty:
     1.1. AE_AML_NO_RESOURCE_END_TAG is returned;
   ? 1.2. UserFunction is not invoked;
   ? 1.3. EndTag location is not returned.
2. When EndTag is missing:
     2.1. AE_AML_NO_RESOURCE_END_TAG is returned;
     2.2. UserFunction is invoked;
     2.3. EndTag location is returned.
3. When EndTag is invalid:
   ? 3.1. AE_AML_NO_RESOURCE_END_TAG is returned;
     3.2. UserFunction is not invoked;
     3.3. EndTag location is not returned.

Problems are marked with question mark.

The 1st issue is:
AML code may use Buffers or empty ResourceTemplates to generate final
resource templates using ConcatenateResTemplate opcode, in which case,
EndTag can be invalid. Thus AcpiUtGetResrouceEndTag() should always return
AE_OK when AE_AML_NO_RESOURCE_END_TAG is encountered and should always
locate the start of EndTag or the end of the resource template.
But there are code paths in AcpiUtWalkAmlResources() never returning EndTag
location, AcpiUtGetResourceEndTag() thus makes a hack to locate EndTag
itself. However the hack can only handle 1.3, cannot handle 3.3.

The 2nd issue is:
Case 1 and case 2 should be equivelent, thus UserFunction should be invoked
for both cases.
Case 3 should be an equivelent case to "invalid resource type" where we
should stop invoking UserFunction and return an error to the caller.

This patch first cleans up AcpiUtWalkAmlResources() logics:
1. Validate resource first (type/length/checksum).
2. If resource is valid, invoke UserFunction right in the loop and
   proceed to the next resource entry.
3. If resource is invalid, break the resource parsing loop and complain
   invalid resource type/length.
4. If EndTag is missing, break the resource parsing loop and invoke
   UserFunction for a fake EndTag after the loop.
5. The EndTag location is always calculated and returned at the end of
   the function.
By doing so, all invalid EndTag cases are handled correctly.

With EndTag location always returned from AcpiUtWalkAmlResources(), this
patch then can remove the EndTag locating hack from
AcpiUtGetResourceEndTag() and can always return AE_OK when
AE_AML_NO_RESOURCE_END_TAG is encountered.

Thus this patch finally sorts out all hidden logics related to invalid
EndTag, making us immune to possible regressions that may occur to
AE_AML_NO_RESOURCE_END_TAG. Lv Zheng.

Signed-off-by: Lv Zheng <lv.zheng@intel.com>