### PR TITLE
Parser: Fix a potential memory leak in AcpiPsGetNextArg()

### DIFF
--- a/source/components/parser/psargs.c
+++ b/source/components/parser/psargs.c
@@ -861,8 +861,6 @@ AcpiPsGetNextArg (
     ACPI_PARSE_OBJECT       **ReturnArg)
 {
     ACPI_PARSE_OBJECT       *Arg = NULL;
-    ACPI_PARSE_OBJECT       *Prev = NULL;
-    ACPI_PARSE_OBJECT       *Field;
     UINT32                  Subop;
     ACPI_STATUS             Status = AE_OK;
 
@@ -907,28 +905,16 @@ AcpiPsGetNextArg (
         {
             /* Non-empty list */
 
-            while (ParserState->Aml < ParserState->PkgEnd)
+            Arg = AcpiPsGetNextField (ParserState);
+            if (!Arg)
             {
-                Field = AcpiPsGetNextField (ParserState);
-                if (!Field)
-                {
-                    return_ACPI_STATUS (AE_NO_MEMORY);
-                }
-
-                if (Prev)
-                {
-                    Prev->Common.Next = Field;
-                }
-                else
-                {
-                    Arg = Field;
-                }
-                Prev = Field;
+                return_ACPI_STATUS (AE_NO_MEMORY);
             }
-
-            /* Skip to End of byte data */
-
-            ParserState->Aml = ParserState->PkgEnd;
+            WalkState->VarArgs = TRUE;
+        }
+        else
+        {
+            WalkState->VarArgs = FALSE;
         }
         break;
 

--- a/source/components/parser/psloop.c
+++ b/source/components/parser/psloop.c
@@ -243,7 +243,10 @@ AcpiPsGetArguments (
                 AcpiPsAppendArg (Op, Arg);
             }
 
-            INCREMENT_ARG_LIST (WalkState->ArgTypes);
+            if (!WalkState->VarArgs)
+            {
+                INCREMENT_ARG_LIST (WalkState->ArgTypes);
+            }
         }
 
 
@@ -559,7 +562,8 @@ AcpiPsParseLoop (
             }
 
             AcpiPsPopScope (ParserState, &Op,
-                &WalkState->ArgTypes, &WalkState->ArgCount);
+                &WalkState->ArgTypes, &WalkState->ArgCount,
+                &WalkState->VarArgs);
             ACPI_DEBUG_PRINT ((ACPI_DB_PARSE, "Popped scope, Op=%p\n", Op));
         }
         else if (WalkState->PrevOp)
@@ -616,6 +620,7 @@ AcpiPsParseLoop (
          * any args yet
          */
         WalkState->ArgCount = 0;
+        WalkState->VarArgs = FALSE;
 
         switch (Op->Common.AmlOpcode)
         {
@@ -660,7 +665,7 @@ AcpiPsParseLoop (
              * prepare for argument
              */
             Status = AcpiPsPushScope (ParserState, Op,
-                WalkState->ArgTypes, WalkState->ArgCount);
+                WalkState->ArgTypes, WalkState->ArgCount, WalkState->VarArgs);
             if (ACPI_FAILURE (Status))
             {
                 Status = AcpiPsCompleteOp (WalkState, &Op, Status);

--- a/source/components/parser/psobject.c
+++ b/source/components/parser/psobject.c
@@ -282,8 +282,14 @@ AcpiPsBuildNamedOp (
             return_ACPI_STATUS (Status);
         }
 
-        AcpiPsAppendArg (UnnamedOp, Arg);
-        INCREMENT_ARG_LIST (WalkState->ArgTypes);
+        if (Arg)
+        {
+            AcpiPsAppendArg (UnnamedOp, Arg);
+        }
+        if (!WalkState->VarArgs)
+        {
+            INCREMENT_ARG_LIST (WalkState->ArgTypes);
+        }
     }
 
     /* are there any inline comments associated with the NameSeg?? If so, save this. */
@@ -571,7 +577,7 @@ AcpiPsCompleteOp (
     case AE_CTRL_END:
 
         AcpiPsPopScope (&(WalkState->ParserState), Op,
-            &WalkState->ArgTypes, &WalkState->ArgCount);
+            &WalkState->ArgTypes, &WalkState->ArgCount, &WalkState->VarArgs);
 
         if (*Op)
         {
@@ -600,7 +606,8 @@ AcpiPsCompleteOp (
         while (!(*Op) || ((*Op)->Common.AmlOpcode != AML_WHILE_OP))
         {
             AcpiPsPopScope (&(WalkState->ParserState), Op,
-                &WalkState->ArgTypes, &WalkState->ArgCount);
+                &WalkState->ArgTypes, &WalkState->ArgCount,
+                &WalkState->VarArgs);
         }
 
         /* Close this iteration of the While loop */
@@ -639,7 +646,8 @@ AcpiPsCompleteOp (
             }
 
             AcpiPsPopScope (&(WalkState->ParserState), Op,
-                &WalkState->ArgTypes, &WalkState->ArgCount);
+                &WalkState->ArgTypes, &WalkState->ArgCount,
+                &WalkState->VarArgs);
 
         } while (*Op);
 
@@ -659,7 +667,8 @@ AcpiPsCompleteOp (
             }
 
             AcpiPsPopScope (&(WalkState->ParserState), Op,
-                &WalkState->ArgTypes, &WalkState->ArgCount);
+                &WalkState->ArgTypes, &WalkState->ArgCount,
+                &WalkState->VarArgs);
 
         } while (*Op);
 
@@ -684,7 +693,7 @@ AcpiPsCompleteOp (
     if (AcpiPsHasCompletedScope (&(WalkState->ParserState)))
     {
         AcpiPsPopScope (&(WalkState->ParserState), Op,
-            &WalkState->ArgTypes, &WalkState->ArgCount);
+            &WalkState->ArgTypes, &WalkState->ArgCount, &WalkState->VarArgs);
         ACPI_DEBUG_PRINT ((ACPI_DB_PARSE, "Popped scope, Op=%p\n", *Op));
     }
     else
@@ -768,7 +777,8 @@ AcpiPsCompleteFinalOp (
                         }
 
                         AcpiPsPopScope (&(WalkState->ParserState), &Op,
-                            &WalkState->ArgTypes, &WalkState->ArgCount);
+                            &WalkState->ArgTypes, &WalkState->ArgCount,
+                            &WalkState->VarArgs);
 
                     } while (Op);
 
@@ -792,7 +802,7 @@ AcpiPsCompleteFinalOp (
         }
 
         AcpiPsPopScope (&(WalkState->ParserState), &Op, &WalkState->ArgTypes,
-            &WalkState->ArgCount);
+            &WalkState->ArgCount, &WalkState->VarArgs);
 
     } while (Op);
 

--- a/source/components/parser/psscope.c
+++ b/source/components/parser/psscope.c
@@ -200,6 +200,7 @@ AcpiPsInitScope (
     Scope->Common.DescriptorType = ACPI_DESC_TYPE_STATE_RPSCOPE;
     Scope->ParseScope.Op = RootOp;
     Scope->ParseScope.ArgCount = ACPI_VAR_ARGS;
+    Scope->ParseScope.VarArgs = FALSE;
     Scope->ParseScope.ArgEnd = ParserState->AmlEnd;
     Scope->ParseScope.PkgEnd = ParserState->AmlEnd;
 
@@ -218,6 +219,7 @@ AcpiPsInitScope (
  *              Op                  - Current op to be pushed
  *              RemainingArgs       - List of args remaining
  *              ArgCount            - Fixed or variable number of args
+ *              VarArgs             - Variable args remaining
  *
  * RETURN:      Status
  *
@@ -230,7 +232,8 @@ AcpiPsPushScope (
     ACPI_PARSE_STATE        *ParserState,
     ACPI_PARSE_OBJECT       *Op,
     UINT32                  RemainingArgs,
-    UINT32                  ArgCount)
+    UINT32                  ArgCount,
+    BOOLEAN                 VarArgs)
 {
     ACPI_GENERIC_STATE      *Scope;
 
@@ -248,6 +251,7 @@ AcpiPsPushScope (
     Scope->ParseScope.Op = Op;
     Scope->ParseScope.ArgList = RemainingArgs;
     Scope->ParseScope.ArgCount = ArgCount;
+    Scope->ParseScope.VarArgs = VarArgs;
     Scope->ParseScope.PkgEnd = ParserState->PkgEnd;
 
     /* Push onto scope stack */
@@ -280,6 +284,7 @@ AcpiPsPushScope (
  *              ArgList             - Where the popped "next argument" is
  *                                    returned
  *              ArgCount            - Count of objects in ArgList
+ *              VarAgs              - Variable args remaining
  *
  * RETURN:      Status
  *
@@ -292,7 +297,8 @@ AcpiPsPopScope (
     ACPI_PARSE_STATE        *ParserState,
     ACPI_PARSE_OBJECT       **Op,
     UINT32                  *ArgList,
-    UINT32                  *ArgCount)
+    UINT32                  *ArgCount,
+    BOOLEAN                 *VarArgs)
 {
     ACPI_GENERIC_STATE      *Scope = ParserState->Scope;
 
@@ -311,6 +317,7 @@ AcpiPsPopScope (
         *Op = Scope->ParseScope.Op;
         *ArgList = Scope->ParseScope.ArgList;
         *ArgCount = Scope->ParseScope.ArgCount;
+        *VarArgs = Scope->ParseScope.VarArgs;
         ParserState->PkgEnd = Scope->ParseScope.PkgEnd;
 
         /* All done with this scope state structure */
@@ -324,6 +331,7 @@ AcpiPsPopScope (
         *Op = NULL;
         *ArgList = 0;
         *ArgCount = 0;
+        *VarArgs = FALSE;
     }
 
     ACPI_DEBUG_PRINT ((ACPI_DB_PARSE,

--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -821,6 +821,7 @@ typedef struct acpi_pscope_state
     UINT8                           *ArgEnd;                /* Current argument end */
     UINT8                           *PkgEnd;                /* Current package end */
     UINT32                          ArgList;                /* Next argument to parse */
+    BOOLEAN                         VarArgs;                /* Variable number of args */
 
 } ACPI_PSCOPE_STATE;
 

--- a/source/include/acparser.h
+++ b/source/include/acparser.h
@@ -312,14 +312,16 @@ AcpiPsPopScope (
     ACPI_PARSE_STATE        *ParserState,
     ACPI_PARSE_OBJECT       **Op,
     UINT32                  *ArgList,
-    UINT32                  *ArgCount);
+    UINT32                  *ArgCount,
+    BOOLEAN                 *VarArgs);
 
 ACPI_STATUS
 AcpiPsPushScope (
     ACPI_PARSE_STATE        *ParserState,
     ACPI_PARSE_OBJECT       *Op,
     UINT32                  RemainingArgs,
-    UINT32                  ArgCount);
+    UINT32                  ArgCount,
+    BOOLEAN                 VarArgs);
 
 void
 AcpiPsCleanupScope (

--- a/source/include/acstruct.h
+++ b/source/include/acstruct.h
@@ -169,6 +169,7 @@ typedef struct acpi_walk_state
     ACPI_PARSE_STATE                ParserState;        /* Current state of parser */
     UINT32                          PrevArgTypes;
     UINT32                          ArgCount;           /* push for fixed or var args */
+    BOOLEAN                         VarArgs;            /* Variable number of arguments */
 
     struct acpi_namespace_node      Arguments[ACPI_METHOD_NUM_ARGS];        /* Control method arguments */
     struct acpi_namespace_node      LocalVariables[ACPI_METHOD_NUM_LOCALS]; /* Control method locals */


### PR DESCRIPTION
It is reported by CoverityScan tool that AcpiPsGetNextArg() contains a
potential memory leak problem in AcpiPsGetNextArg() when FIELDLIST is
parsed (Link #1).

This patch fixes this issue by introducing a concept of a specific type of
argument which can contain variable number of elements. By doing so, this
patch also sorts the order of the fields. Now fields are stored in the
parser in the same order as they appear in the AML.

Instead of cleaning up ArgCount (which was designed for the same purpose,
but used as the indicator of initiating a new stacked parser state), this
patch introduces VarArgs to support the arguments that can contain variable
number of elements.

Link: https://bugs.acpica.org/show_bug.cgi?id=1335 [#1]
Reported-by: Colin Ian King <colin.king@canonical.com>
Signed-off-by: Lv Zheng <lv.zheng@intel.com>