### PR TITLE
Add deferred package initialization support

### DIFF
--- a/source/components/dispatcher/dsargs.c
+++ b/source/components/dispatcher/dsargs.c
@@ -459,6 +459,15 @@ AcpiDsGetPackageArguments (
     ACPI_FUNCTION_TRACE_PTR (DsGetPackageArguments, ObjDesc);
 
 
+    /*
+     * Resolve all named references in package objects (and all
+     * sub-packages). This action has been deferred until the entire
+     * namespace has been loaded, in order to support external and
+     * forward references from individual package elements (05/2017).
+     */
+    (void) AcpiUtWalkPackageTree (ObjDesc, NULL,
+            AcpiDsInitPackageElement, NULL);
+
     if (ObjDesc->Common.Flags & AOPOBJ_DATA_VALID)
     {
         return_ACPI_STATUS (AE_OK);

--- a/source/components/namespace/nsinit.c
+++ b/source/components/namespace/nsinit.c
@@ -492,7 +492,8 @@ AcpiNsInitOneObject (
 
     /* If the object is already initialized, nothing else to do */
 
-    if (ObjDesc->Common.Flags & AOPOBJ_DATA_VALID)
+    if (ObjDesc->Common.Flags & AOPOBJ_DATA_VALID &&
+        ObjDesc->Common.Type != ACPI_TYPE_PACKAGE)
     {
         return (AE_OK);
     }

--- a/source/components/utilities/utmisc.c
+++ b/source/components/utilities/utmisc.c
@@ -395,8 +395,10 @@ AcpiUtWalkPackageTree (
         /* Get one element of the package */
 
         ThisIndex = State->Pkg.Index;
-        ThisSourceObj = (ACPI_OPERAND_OBJECT *)
+        ThisSourceObj =
             State->Pkg.SourceObject->Package.Elements[ThisIndex];
+        State->Pkg.ThisTargetObj =
+            &State->Pkg.SourceObject->Package.Elements[ThisIndex];
 
         /*
          * Check for:

--- a/source/include/acdispat.h
+++ b/source/include/acdispat.h
@@ -430,6 +430,13 @@ AcpiDsInitObjectFromOp (
     ACPI_OPERAND_OBJECT     **ObjDesc);
 
 ACPI_STATUS
+AcpiDsInitPackageElement (
+    UINT8                   ObjectType,
+    ACPI_OPERAND_OBJECT     *SourceObject,
+    ACPI_GENERIC_STATE      *State,
+    void                    *Context);
+
+ACPI_STATUS
 AcpiDsCreateNode (
     ACPI_WALK_STATE         *WalkState,
     ACPI_NAMESPACE_NODE     *Node,

--- a/source/include/acobject.h
+++ b/source/include/acobject.h
@@ -546,11 +546,12 @@ typedef struct acpi_object_reference
     ACPI_OBJECT_COMMON_HEADER
     UINT8                           Class;              /* Reference Class */
     UINT8                           TargetType;         /* Used for Index Op */
-    UINT8                           Reserved;
+    UINT8                           Resolved;           /* ObjectReference has been resolved to a value */
     void                            *Object;            /* NameOp=>HANDLE to obj, IndexOp=>ACPI_OPERAND_OBJECT */
     ACPI_NAMESPACE_NODE             *Node;              /* RefOf or Namepath */
     union acpi_operand_object       **Where;            /* Target of Index */
     UINT8                           *IndexPointer;      /* Used for Buffers and Strings */
+    UINT8                           *Aml;               /* Used for deferred resolution of ObjectReference */
     UINT32                          Value;              /* Used for Local/Arg/Index/DdbHandle */
 
 } ACPI_OBJECT_REFERENCE;

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -310,7 +310,7 @@ ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_GroupModuleLevelCode, FALSE);
  * a TermList. Default is FALSE, do not execute entire table until some
  * lock order issues are fixed.
  */
-ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_ParseTableAsTermList, FALSE);
+ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_ParseTableAsTermList, TRUE);
 
 /*
  * Optionally use 32-bit FADT addresses if and when there is a conflict


### PR DESCRIPTION
This patch adds deferred package initialization to support forward
references in packages. In order to allow instant package accesses
(shouldn't be in real world, but is useful for ASLTS), this patch keeps
APOBJ_DATA_VALID and resolves name strings in AcpiDsGetPackageArguments()
which is invoked in deferred initialization for table load and instantly
for method evaluation. Note that reference counting of package elements
are still handled in a way not fully compliant to current design as the
design may be changed to achieve efficiency. Robert Moore, Lv Zheng.

Signed-off-by: Bob Moore <robert.moore@intel.com>
Signed-off-by: Lv Zheng <lv.zheng@intel.com>