### PR TITLE
Events: Add a new initialization flag to bypass SystemMemory/SystemIo…

### DIFF
--- a/source/components/events/evhandler.c
+++ b/source/components/events/evhandler.c
@@ -222,57 +222,6 @@ UnlockAndExit:
 
 /*******************************************************************************
  *
- * FUNCTION:    AcpiEvHasDefaultHandler
- *
- * PARAMETERS:  Node                - Namespace node for the device
- *              SpaceId             - The address space ID
- *
- * RETURN:      TRUE if default handler is installed, FALSE otherwise
- *
- * DESCRIPTION: Check if the default handler is installed for the requested
- *              space ID.
- *
- ******************************************************************************/
-
-BOOLEAN
-AcpiEvHasDefaultHandler (
-    ACPI_NAMESPACE_NODE     *Node,
-    ACPI_ADR_SPACE_TYPE     SpaceId)
-{
-    ACPI_OPERAND_OBJECT     *ObjDesc;
-    ACPI_OPERAND_OBJECT     *HandlerObj;
-
-
-    /* Must have an existing internal object */
-
-    ObjDesc = AcpiNsGetAttachedObject (Node);
-    if (ObjDesc)
-    {
-        HandlerObj = ObjDesc->CommonNotify.Handler;
-
-        /* Walk the linked list of handlers for this object */
-
-        while (HandlerObj)
-        {
-            if (HandlerObj->AddressSpace.SpaceId == SpaceId)
-            {
-                if (HandlerObj->AddressSpace.HandlerFlags &
-                    ACPI_ADDR_HANDLER_DEFAULT_INSTALLED)
-                {
-                    return (TRUE);
-                }
-            }
-
-            HandlerObj = HandlerObj->AddressSpace.Next;
-        }
-    }
-
-    return (FALSE);
-}
-
-
-/*******************************************************************************
- *
  * FUNCTION:    AcpiEvInstallHandler
  *
  * PARAMETERS:  WalkNamespace callback

--- a/source/components/events/evregion.c
+++ b/source/components/events/evregion.c
@@ -143,7 +143,7 @@ AcpiEvRegRun (
  *
  * FUNCTION:    AcpiEvInitializeOpRegions
  *
- * PARAMETERS:  None
+ * PARAMETERS:  Flags               - Init/enable Options
  *
  * RETURN:      Status
  *
@@ -154,14 +154,18 @@ AcpiEvRegRun (
 
 ACPI_STATUS
 AcpiEvInitializeOpRegions (
-    void)
+    UINT32                  Flags)
 {
     ACPI_STATUS             Status;
     UINT32                  i;
+    ACPI_ADR_SPACE_TYPE     SpaceId;
 
 
     ACPI_FUNCTION_TRACE (EvInitializeOpRegions);
 
+
+    ACPI_DEBUG_PRINT ((ACPI_DB_EXEC,
+        "[Init] Executing _REG OpRegion methods\n"));
 
     Status = AcpiUtAcquireMutex (ACPI_MTX_NAMESPACE);
     if (ACPI_FAILURE (Status))
@@ -174,16 +178,48 @@ AcpiEvInitializeOpRegions (
     for (i = 0; i < ACPI_NUM_DEFAULT_SPACES; i++)
     {
         /*
-         * Make sure the installed handler is the DEFAULT handler. If not the
-         * default, the _REG methods will have already been run (when the
-         * handler was installed)
+         * According to the ACPI specification, OSPM must guarantee that
+         * the following operation regions must always be accessible:
+         * 1. PCI_Config on a PCI root bus containing a _BBN object.
+         * 2. I/O operation regions.
+         * 3. Memory operation regions when accessing memory returnd by the
+         *    System Address Map reporting interface.
+         * So OSPM is allowed to discard _REG evaluations for SystemIo and
+         * SystemMemory operation regions while still be able to evaluate
+         * _REG for PCI_Config on other device nodes.
+         *
+         * Note that DataTable operation region is defined by ACPICA and
+         * used internally without external dependencies, it should always
+         * be accessible.
          */
-        if (AcpiEvHasDefaultHandler (AcpiGbl_RootNode,
-               AcpiGbl_DefaultAddressSpaces[i]))
+        SpaceId = AcpiGbl_DefaultAddressSpaces[i];
+        switch (SpaceId)
         {
-            AcpiEvExecuteRegMethods (AcpiGbl_RootNode,
-                AcpiGbl_DefaultAddressSpaces[i], ACPI_REG_CONNECT);
+        case ACPI_ADR_SPACE_SYSTEM_MEMORY:
+        case ACPI_ADR_SPACE_SYSTEM_IO:
+
+            if (Flags & ACPI_NO_SYSTEM_SPACES_INIT)
+            {
+                continue;
+            }
+            break;
+
+        case ACPI_ADR_SPACE_PCI_CONFIG:
+
+            if (Flags & ACPI_NO_PCI_CONFIG_INIT)
+            {
+                continue;
+            }
+            break;
+
+        case ACPI_ADR_SPACE_DATA_TABLE:
+        default:
+
+            continue;
         }
+
+        AcpiEvExecuteRegMethods (AcpiGbl_RootNode, SpaceId,
+            ACPI_REG_CONNECT);
     }
 
     (void) AcpiUtReleaseMutex (ACPI_MTX_NAMESPACE);

--- a/source/components/namespace/nsinit.c
+++ b/source/components/namespace/nsinit.c
@@ -212,7 +212,7 @@ AcpiNsInitializeObjects (
  *
  * FUNCTION:    AcpiNsInitializeDevices
  *
- * PARAMETERS:  None
+ * PARAMETERS:  Flags               - Init/enable Options
  *
  * RETURN:      ACPI_STATUS
  *
@@ -320,16 +320,10 @@ AcpiNsInitializeDevices (
      * root bus that doesn't contain _BBN object. So this code is kept here
      * in order not to break things.
      */
-    if (!(Flags & ACPI_NO_ADDRESS_SPACE_INIT))
+    Status = AcpiEvInitializeOpRegions (Flags);
+    if (ACPI_FAILURE (Status))
     {
-        ACPI_DEBUG_PRINT ((ACPI_DB_EXEC,
-            "[Init] Executing _REG OpRegion methods\n"));
-
-        Status = AcpiEvInitializeOpRegions ();
-        if (ACPI_FAILURE (Status))
-        {
-            goto ErrorExit;
-        }
+        goto ErrorExit;
     }
 
     if (!(Flags & ACPI_NO_DEVICE_INIT))

--- a/source/components/utilities/utxfinit.c
+++ b/source/components/utilities/utxfinit.c
@@ -389,13 +389,10 @@ AcpiInitializeObjects (
      * Initialize all device/region objects in the namespace. This runs
      * the device _STA and _INI methods and region _REG methods.
      */
-    if (!(Flags & (ACPI_NO_DEVICE_INIT | ACPI_NO_ADDRESS_SPACE_INIT)))
+    Status = AcpiNsInitializeDevices (Flags);
+    if (ACPI_FAILURE (Status))
     {
-        Status = AcpiNsInitializeDevices (Flags);
-        if (ACPI_FAILURE (Status))
-        {
-            return_ACPI_STATUS (Status);
-        }
+        return_ACPI_STATUS (Status);
     }
 
     /*

--- a/source/include/acevents.h
+++ b/source/include/acevents.h
@@ -304,11 +304,6 @@ AcpiEvFindRegionHandler (
     ACPI_ADR_SPACE_TYPE     SpaceId,
     ACPI_OPERAND_OBJECT     *HandlerObj);
 
-BOOLEAN
-AcpiEvHasDefaultHandler (
-    ACPI_NAMESPACE_NODE     *Node,
-    ACPI_ADR_SPACE_TYPE     SpaceId);
-
 ACPI_STATUS
 AcpiEvInstallRegionHandlers (
     void);
@@ -327,7 +322,7 @@ AcpiEvInstallSpaceHandler (
  */
 ACPI_STATUS
 AcpiEvInitializeOpRegions (
-    void);
+    UINT32                  Flags);
 
 ACPI_STATUS
 AcpiEvAddressSpaceDispatch (

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -646,15 +646,16 @@ typedef UINT64                          ACPI_INTEGER;
 /*
  * Initialization sequence
  */
-#define ACPI_FULL_INITIALIZATION        0x00
-#define ACPI_NO_ADDRESS_SPACE_INIT      0x01
-#define ACPI_NO_HARDWARE_INIT           0x02
-#define ACPI_NO_EVENT_INIT              0x04
-#define ACPI_NO_HANDLER_INIT            0x08
-#define ACPI_NO_ACPI_ENABLE             0x10
-#define ACPI_NO_DEVICE_INIT             0x20
-#define ACPI_NO_OBJECT_INIT             0x40
-#define ACPI_NO_FACS_INIT               0x80
+#define ACPI_FULL_INITIALIZATION        0x000
+#define ACPI_NO_HARDWARE_INIT           0x001
+#define ACPI_NO_EVENT_INIT              0x002
+#define ACPI_NO_HANDLER_INIT            0x004
+#define ACPI_NO_ACPI_ENABLE             0x008
+#define ACPI_NO_DEVICE_INIT             0x010
+#define ACPI_NO_OBJECT_INIT             0x020
+#define ACPI_NO_FACS_INIT               0x040
+#define ACPI_NO_SYSTEM_SPACES_INIT      0x080
+#define ACPI_NO_PCI_CONFIG_INIT         0x100
 
 /*
  * Initialization state

--- a/source/tools/acpinames/anmain.c
+++ b/source/tools/acpinames/anmain.c
@@ -338,7 +338,6 @@ AnDumpEntireNamespace (
      */
     Status = AcpiEnableSubsystem (
         ACPI_NO_ACPI_ENABLE |
-        ACPI_NO_ADDRESS_SPACE_INIT |
         ACPI_NO_EVENT_INIT |
         ACPI_NO_HANDLER_INIT);
     if (ACPI_FAILURE (Status))
@@ -349,7 +348,8 @@ AnDumpEntireNamespace (
     }
 
     Status = AcpiInitializeObjects (
-        ACPI_NO_ADDRESS_SPACE_INIT |
+        ACPI_NO_SYSTEM_SPACES_INIT |
+        ACPI_NO_PCI_CONFIG_INIT |
         ACPI_NO_DEVICE_INIT |
         ACPI_NO_EVENT_INIT);
     if (ACPI_FAILURE (Status))

--- a/source/tools/acpinames/anstubs.c
+++ b/source/tools/acpinames/anstubs.c
@@ -177,7 +177,7 @@ AcpiEvInstallRegionHandlers (
 
 ACPI_STATUS
 AcpiEvInitializeOpRegions (
-    void)
+    UINT32                  Flags)
 {
     return (AE_OK);
 }


### PR DESCRIPTION
… operation region initialization

According to the spec and the de-facto standard behavior, it is not
required to execute _REG(SystemMemory, CONNECT) and
_REG(SystemIo, CONNECT) while it is required to execute
_REG(PCI_Config, CONNECT) for the operation regions under a non PCI root
bridge device node.
This patch adds an additional operation region initialization flag to make
it possible for OSPMs to bypass SystemIo/SystemMemory _REG evaluations. The
AcpiEvHasDefaultHandler() is removed accordingly because we actually should
always execute _REG at this point whatever the handler is installed by
ACPICA or an external driver and when the handler is installed, _REG
executions are blocked even though it is a handler from an external driver.

Note that this patch stops evaluating _REG(DataTable, CONNECT), because
this operation region is not defined by the ACPI specification, but designed
by ACPICA itself for internal testing purpose and there is no external
dependencies required for accessing it. Lv Zheng.

Link: https://bugzilla.kernel.org/show_bug.cgi?id=102421
Signed-off-by: Lv Zheng <lv.zheng@intel.com>