### PR TITLE
ASLTS: getting rid of external declaration causing re-definition of _ERR

### DIFF
--- a/tests/aslts/src/runtime/cntl/ehandle.asl
+++ b/tests/aslts/src/runtime/cntl/ehandle.asl
@@ -26,8 +26,6 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-External (_ERR, MethodObj)
-
 /*
  * Exceptional conditions support
  */


### PR DESCRIPTION
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>