### PR TITLE
disassmbler: Add more checks to switch disassembly function

### DIFF
--- a/source/include/amlcode.h
+++ b/source/include/amlcode.h
@@ -246,7 +246,7 @@
 #define AML_RETURN_OP               (UINT16) 0xa4
 #define AML_BREAK_OP                (UINT16) 0xa5
 #define AML_COMMENT_OP              (UINT16) 0xa9
-#define AML_BREAKPOINT_OP          (UINT16) 0xcc
+#define AML_BREAKPOINT_OP           (UINT16) 0xcc
 #define AML_ONES_OP                 (UINT16) 0xff
 
 


### PR DESCRIPTION
Add more checks to ensure structure the proper structure of a
switch statement before doing the conversion.

Signed-off-by: David E. Box <david.e.box@linux.intel.com>